### PR TITLE
Add mobile header menu toggle and responsive header layout

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,12 +24,41 @@ const {
 
   <body class="min-h-screen bg-bg text-fg">
     <div class="mx-auto max-w-6xl px-4">
-      <header class="py-6 flex items-center justify-between gap-4">
-        <a href="/" class="font-semibold tracking-tight text-lg text-fg">
+      <header
+        class="py-6 flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left"
+      >
+        <a
+          href="/"
+          class="font-semibold tracking-tight text-base leading-tight text-fg sm:text-lg"
+        >
           Timber and Tides Woodcraft
         </a>
 
-        <nav class="flex gap-4 text-sm text-muted">
+        <button
+          class="inline-flex items-center gap-2 text-sm text-muted transition hover:text-fg sm:hidden"
+          type="button"
+          aria-expanded="false"
+          aria-controls="site-nav"
+          data-nav-toggle
+        >
+          <span class="sr-only">Toggle navigation</span>
+          <svg
+            aria-hidden="true"
+            class="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            stroke-width="2"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+          Menu
+        </button>
+
+        <nav
+          id="site-nav"
+          class="hidden w-full flex flex-col items-center gap-3 text-sm text-muted sm:flex sm:w-auto sm:flex-row sm:gap-4"
+        >
           <a class="hover:text-fg transition" href="/projects/">Projects</a>
           <a class="hover:text-fg transition" href="/testimonials/">Feedback</a>
           <a class="hover:text-fg transition" href="/contact/">Contact</a>
@@ -48,5 +77,18 @@ const {
         </div>
       </footer>
     </div>
+
+    <script>
+      const toggleButton = document.querySelector("[data-nav-toggle]");
+      const nav = document.querySelector("#site-nav");
+
+      if (toggleButton && nav) {
+        toggleButton.addEventListener("click", () => {
+          const isExpanded = toggleButton.getAttribute("aria-expanded") === "true";
+          toggleButton.setAttribute("aria-expanded", String(!isExpanded));
+          nav.classList.toggle("hidden");
+        });
+      }
+    </script>
   </body>
 </html>


### PR DESCRIPTION
### Motivation
- Improve the header on small screens by stacking and centering the brand while keeping the desktop layout intact.
- Provide a hamburger/menu button so mobile users can show or hide the navigation.
- Maintain accessibility by annotating the toggle with `aria-expanded` and `aria-controls`.

### Description
- Updated `src/layouts/BaseLayout.astro` to use a column-centered header on small screens with `sm:` breakpoints for the desktop layout.
- Added a hamburger `button` (with `data-nav-toggle`, `aria-expanded="false"`, and inline SVG) that is visible only on small screens (`sm:hidden`).
- Converted the nav into an element with `id="site-nav"` that is `hidden` by default on mobile and becomes `sm:flex` on larger screens.
- Included a small inline script that toggles the button's `aria-expanded` value and toggles the nav's `hidden` class when clicked.

### Testing
- Ran `npm install`, which completed but emitted warnings about `http-proxy` and a `MaxListenersExceededWarning`.
- Attempted to start the dev server with `npm run dev -- --host 0.0.0.0 --port 4321`, which failed because the `astro` binary was not found.
- Attempted `npx astro dev --host 0.0.0.0 --port 4321`, which failed with an npm registry `403 Forbidden` error so the local dev server could not be started.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695da840abbc83309db62dc3260141b6)