### PR TITLE
Animated overlay mobile nav and full-width sections

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -23,9 +23,9 @@ const {
   </head>
 
   <body class="min-h-screen bg-bg text-fg">
-    <div class="mx-auto max-w-6xl px-4">
-      <header
-        class="py-6 flex flex-col items-center gap-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left"
+    <header class="py-6">
+      <div
+        class="relative mx-auto flex max-w-6xl flex-col items-center gap-4 px-4 text-center sm:flex-row sm:items-center sm:justify-between sm:text-left"
       >
         <a
           href="/"
@@ -52,41 +52,64 @@ const {
           >
             <path stroke-linecap="round" stroke-linejoin="round" d="M4 6h16M4 12h16M4 18h16" />
           </svg>
-          Menu
         </button>
 
         <nav
           id="site-nav"
-          class="hidden w-full flex flex-col items-center gap-3 text-sm text-muted sm:flex sm:w-auto sm:flex-row sm:gap-4"
+          class="absolute left-0 right-0 top-full z-20 mt-4 flex w-full flex-col items-center gap-3 overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-900/95 px-6 py-4 text-sm text-muted shadow-lg backdrop-blur transition-[max-height,opacity,transform] duration-300 ease-out max-h-0 opacity-0 -translate-y-2 pointer-events-none sm:static sm:mt-0 sm:flex sm:w-auto sm:flex-row sm:gap-4 sm:border-0 sm:bg-transparent sm:p-0 sm:shadow-none sm:backdrop-blur-none sm:max-h-none sm:opacity-100 sm:translate-y-0 sm:pointer-events-auto sm:overflow-visible"
         >
           <a class="hover:text-fg transition" href="/projects/">Projects</a>
           <a class="hover:text-fg transition" href="/testimonials/">Feedback</a>
           <a class="hover:text-fg transition" href="/contact/">Contact</a>
         </nav>
-      </header>
+      </div>
+    </header>
 
+    <main class="pb-16">
+      <slot />
+    </main>
 
-      <main class="pb-16">
-        <slot />
-      </main>
-
-      <footer class="border-t border-zinc-800 py-8 text-sm text-zinc-400">
-        <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-          <p>&copy; {new Date().getFullYear()} Timber and Tides Woodcraft</p>
-          <p class="text-zinc-500">Colorado • Commissions welcome</p>
-        </div>
-      </footer>
-    </div>
+    <footer class="border-t border-zinc-800 py-8 text-sm text-zinc-400">
+      <div class="mx-auto flex max-w-6xl flex-col gap-2 px-4 sm:flex-row sm:items-center sm:justify-between">
+        <p>&copy; {new Date().getFullYear()} Timber and Tides Woodcraft</p>
+        <p class="text-zinc-500">Colorado • Commissions welcome</p>
+      </div>
+    </footer>
 
     <script>
       const toggleButton = document.querySelector("[data-nav-toggle]");
       const nav = document.querySelector("#site-nav");
 
       if (toggleButton && nav) {
-        toggleButton.addEventListener("click", () => {
-          const isExpanded = toggleButton.getAttribute("aria-expanded") === "true";
-          toggleButton.setAttribute("aria-expanded", String(!isExpanded));
-          nav.classList.toggle("hidden");
+        const openClasses = ["max-h-96", "opacity-100", "translate-y-0", "pointer-events-auto"];
+        const closedClasses = ["max-h-0", "opacity-0", "-translate-y-2", "pointer-events-none"];
+        let isOpen = false;
+
+        const setNavState = (nextOpen) => {
+          isOpen = nextOpen;
+          toggleButton.setAttribute("aria-expanded", String(isOpen));
+          openClasses.forEach((cls) => nav.classList.toggle(cls, isOpen));
+          closedClasses.forEach((cls) => nav.classList.toggle(cls, !isOpen));
+        };
+
+        const toggleNav = () => setNavState(!isOpen);
+
+        toggleButton.addEventListener("click", (event) => {
+          event.stopPropagation();
+          toggleNav();
+        });
+
+        document.addEventListener("click", (event) => {
+          if (!isOpen) return;
+          const target = event.target;
+          if (target instanceof Node && (nav.contains(target) || toggleButton.contains(target))) return;
+          setNavState(false);
+        });
+
+        window.addEventListener("keydown", (event) => {
+          if (event.key === "Escape") {
+            setNavState(false);
+          }
         });
       }
     </script>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,26 +8,28 @@ const mailto = `mailto:${EMAIL}?subject=${encodeURIComponent(SUBJECT)}`;
 
 <BaseLayout title="Contact — Woodshop" description="Request a commission via email.">
   <section class="py-8">
-    <h1 class="text-3xl font-bold tracking-tight">Contact</h1>
-    <p class="mt-2 text-zinc-300 max-w-2xl">
-      Want a custom piece? Email me with a quick description and I’ll get back to you with questions, timing, and an estimate.
-    </p>
+    <div class="mx-auto max-w-6xl px-4">
+      <h1 class="text-3xl font-bold tracking-tight">Contact</h1>
+      <p class="mt-2 text-zinc-300 max-w-2xl">
+        Want a custom piece? Email me with a quick description and I’ll get back to you with questions, timing, and an estimate.
+      </p>
 
-    <div class="mt-6 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-6">
-      <p class="text-sm text-zinc-300">Email</p>
-      <a class="mt-1 block text-lg font-semibold text-white hover:underline" href={mailto}>
-        {EMAIL}
-      </a>
+      <div class="mt-6 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-6">
+        <p class="text-sm text-zinc-300">Email</p>
+        <a class="mt-1 block text-lg font-semibold text-white hover:underline" href={mailto}>
+          {EMAIL}
+        </a>
 
-      <div class="mt-6">
-        <h2 class="text-base font-semibold">What to include</h2>
-        <ul class="mt-2 list-disc pl-5 text-sm text-zinc-300 space-y-1">
-          <li>What you want built + any inspiration photos/links</li>
-          <li>Approximate dimensions</li>
-          <li>Preferred wood species + finish (if you know)</li>
-          <li>Deadline (if any)</li>
-          <li>Budget range (helps me propose options)</li>
-        </ul>
+        <div class="mt-6">
+          <h2 class="text-base font-semibold">What to include</h2>
+          <ul class="mt-2 list-disc pl-5 text-sm text-zinc-300 space-y-1">
+            <li>What you want built + any inspiration photos/links</li>
+            <li>Approximate dimensions</li>
+            <li>Preferred wood species + finish (if you know)</li>
+            <li>Deadline (if any)</li>
+            <li>Budget range (helps me propose options)</li>
+          </ul>
+        </div>
       </div>
     </div>
   </section>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -14,14 +14,14 @@ const featured = projects
   title="Timber and Tides Woodcraft"
   description="Handcrafted woodworking projects, client feedback, and commission requests."
 >
-  <section class="px-4 py-10 rounded-3xl border border-border bg-surface relative overflow-hidden">
+  <section class="relative overflow-hidden bg-surface py-10">
     <div
       class="absolute inset-0 opacity-30 pointer-events-none"
       style="background: radial-gradient(800px circle at 20% 10%, var(--color-deep), transparent 60%),
                           radial-gradient(700px circle at 80% 30%, var(--color-primary), transparent 55%);"
     ></div>
 
-    <div class="relative">
+    <div class="relative mx-auto max-w-6xl px-4">
       <h1 class="text-3xl sm:text-4xl font-bold tracking-tight">
         Handcrafted woodworking, built to last.
       </h1>
@@ -59,41 +59,45 @@ const featured = projects
   </section>
 
   <section class="mt-8">
-    <div class="flex items-end justify-between gap-4">
-      <h2 class="text-xl font-semibold">Featured Projects</h2>
-      <a class="text-primary hover:text-fg transition" href="/projects/">See all →</a>
-    </div>
-
-    {featured.length === 0 ? (
-      <p class="mt-4 text-zinc-300">
-        Add a project in <code class="text-zinc-200">src/content/projects</code> to get started.
-      </p>
-    ) : (
-      <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-        {featured.map((p) => (
-          <ProjectCard
-            href={`/projects/${p.slug}/`}
-            title={p.data.title}
-            excerpt={p.data.excerpt}
-            coverImage={p.data.coverImage}
-            tags={p.data.tags}
-          />
-        ))}
+    <div class="mx-auto max-w-6xl px-4">
+      <div class="flex items-end justify-between gap-4">
+        <h2 class="text-xl font-semibold">Featured Projects</h2>
+        <a class="text-primary hover:text-fg transition" href="/projects/">See all →</a>
       </div>
-    )}
+
+      {featured.length === 0 ? (
+        <p class="mt-4 text-zinc-300">
+          Add a project in <code class="text-zinc-200">src/content/projects</code> to get started.
+        </p>
+      ) : (
+        <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {featured.map((p) => (
+            <ProjectCard
+              href={`/projects/${p.slug}/`}
+              title={p.data.title}
+              excerpt={p.data.excerpt}
+              coverImage={p.data.coverImage}
+              tags={p.data.tags}
+            />
+          ))}
+        </div>
+      )}
+    </div>
   </section>
 
-  <section class="mt-10 rounded-2xl border border-zinc-800 bg-zinc-900/40 p-4">
-    <h2 class="text-lg font-semibold">Plans Coming Soon</h2>
-    <p class="mt-2 text-sm text-zinc-300 max-w-2xl">
-      I’m working on publishing a small library of plans and cut lists. Check back later — or email me if there’s a plan you’d love to see.
-    </p>
-    <a
-      href="/contact/"
-      class="mt-4 inline-flex rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm font-semibold text-zinc-100 hover:bg-zinc-800 transition"
-    >
-      Suggest a plan idea
-    </a>
+  <section class="mt-10 bg-zinc-900/40">
+    <div class="mx-auto max-w-6xl px-4 py-6">
+      <h2 class="text-lg font-semibold">Plans Coming Soon</h2>
+      <p class="mt-2 text-sm text-zinc-300 max-w-2xl">
+        I’m working on publishing a small library of plans and cut lists. Check back later — or email me if there’s a plan you’d love to see.
+      </p>
+      <a
+        href="/contact/"
+        class="mt-4 inline-flex rounded-xl border border-zinc-700 bg-zinc-900 px-4 py-2 text-sm font-semibold text-zinc-100 hover:bg-zinc-800 transition"
+      >
+        Suggest a plan idea
+      </a>
+    </div>
   </section>
 
 </BaseLayout>

--- a/src/pages/projects/[slug].astro
+++ b/src/pages/projects/[slug].astro
@@ -19,31 +19,33 @@ const d = project.data;
 
 <BaseLayout title={`${d.title} — Projects`} description={d.excerpt ?? "Woodworking project details."}>
   <article class="py-8">
-    <a href="/projects/" class="text-sm text-zinc-300 hover:text-white">← Back to projects</a>
+    <div class="mx-auto max-w-6xl px-4">
+      <a href="/projects/" class="text-sm text-zinc-300 hover:text-white">← Back to projects</a>
 
-    <h1 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight">{d.title}</h1>
+      <h1 class="mt-3 text-3xl sm:text-4xl font-bold tracking-tight">{d.title}</h1>
 
-    <div class="mt-3 flex flex-wrap gap-2 text-sm text-zinc-300">
-      <span>{d.date.toLocaleDateString()}</span>
-      {d.wood && <span>• Wood: {d.wood}</span>}
-      {d.finish && <span>• Finish: {d.finish}</span>}
-      {d.dimensions && <span>• Size: {d.dimensions}</span>}
-    </div>
-
-    {d.tags?.length > 0 && (
-      <div class="mt-4 flex flex-wrap gap-2">
-        {d.tags.map((t) => <TagPill tag={t} />)}
+      <div class="mt-3 flex flex-wrap gap-2 text-sm text-zinc-300">
+        <span>{d.date.toLocaleDateString()}</span>
+        {d.wood && <span>• Wood: {d.wood}</span>}
+        {d.finish && <span>• Finish: {d.finish}</span>}
+        {d.dimensions && <span>• Size: {d.dimensions}</span>}
       </div>
-    )}
 
-    <div class="mt-6 overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-900">
-      <img src={d.coverImage} alt={d.title} class="h-full w-full object-cover" />
+      {d.tags?.length > 0 && (
+        <div class="mt-4 flex flex-wrap gap-2">
+          {d.tags.map((t) => <TagPill tag={t} />)}
+        </div>
+      )}
+
+      <div class="mt-6 overflow-hidden rounded-2xl border border-zinc-800 bg-zinc-900">
+        <img src={d.coverImage} alt={d.title} class="h-full w-full object-cover" />
+      </div>
+
+      <div class="prose prose-invert mt-8 max-w-none prose-headings:tracking-tight prose-a:text-white">
+        <Content />
+      </div>
+
+      <Gallery images={d.gallery} altPrefix={d.title} />
     </div>
-
-    <div class="prose prose-invert mt-8 max-w-none prose-headings:tracking-tight prose-a:text-white">
-      <Content />
-    </div>
-
-    <Gallery images={d.gallery} altPrefix={d.title} />
   </article>
 </BaseLayout>

--- a/src/pages/projects/index.astro
+++ b/src/pages/projects/index.astro
@@ -10,21 +10,23 @@ const projects = (await getCollection("projects")).sort(
 
 <BaseLayout title="Projects — Woodshop" description="Browse woodworking projects and case studies.">
   <section class="py-8">
-    <h1 class="text-3xl font-bold tracking-tight">Projects</h1>
-    <p class="mt-2 text-zinc-300 max-w-2xl">
-      A selection of commissioned builds, personal projects, and experiments.
-    </p>
+    <div class="mx-auto max-w-6xl px-4">
+      <h1 class="text-3xl font-bold tracking-tight">Projects</h1>
+      <p class="mt-2 text-zinc-300 max-w-2xl">
+        A selection of commissioned builds, personal projects, and experiments.
+      </p>
 
-    <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
-      {projects.map((p) => (
-        <ProjectCard
-          href={`/projects/${p.slug}/`}
-          title={p.data.title}
-          excerpt={p.data.excerpt}
-          coverImage={p.data.coverImage}
-          tags={p.data.tags}
-        />
-      ))}
+      <div class="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {projects.map((p) => (
+          <ProjectCard
+            href={`/projects/${p.slug}/`}
+            title={p.data.title}
+            excerpt={p.data.excerpt}
+            coverImage={p.data.coverImage}
+            tags={p.data.tags}
+          />
+        ))}
+      </div>
     </div>
   </section>
 </BaseLayout>

--- a/src/pages/testimonials.astro
+++ b/src/pages/testimonials.astro
@@ -11,38 +11,40 @@ const testimonials = (await getCollection("testimonials")).sort((a, b) => {
 
 <BaseLayout title="Feedback — Timber & Tides Woodcraft" description="Customer feedback and project accolades.">
   <section class="py-8">
-    <h1 class="text-3xl font-bold tracking-tight">Feedback</h1>
-    <p class="mt-2 text-zinc-300 max-w-2xl">
-      A few notes from clients and recipients.
-    </p>
+    <div class="mx-auto max-w-6xl px-4">
+      <h1 class="text-3xl font-bold tracking-tight">Feedback</h1>
+      <p class="mt-2 text-zinc-300 max-w-2xl">
+        A few notes from clients and recipients.
+      </p>
 
-    <div class="mt-6 grid gap-4">
-      {testimonials.map(async (t) => {
-        const { Content } = await t.render();
+      <div class="mt-6 grid gap-4">
+        {testimonials.map(async (t) => {
+          const { Content } = await t.render();
 
-        return (
-          <article class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
-            <div class="text-zinc-100 text-base leading-relaxed">
-              <Content />
-            </div>
+          return (
+            <article class="rounded-2xl border border-zinc-800 bg-zinc-900/40 p-5">
+              <div class="text-zinc-100 text-base leading-relaxed">
+                <Content />
+              </div>
 
-            <div class="mt-4 text-sm text-zinc-300">
-              <span class="font-semibold text-zinc-100">{t.data.name}</span>
-              {t.data.roleOrContext && (
-                <span class="text-zinc-400"> — {t.data.roleOrContext}</span>
-              )}
+              <div class="mt-4 text-sm text-zinc-300">
+                <span class="font-semibold text-zinc-100">{t.data.name}</span>
+                {t.data.roleOrContext && (
+                  <span class="text-zinc-400"> — {t.data.roleOrContext}</span>
+                )}
 
-              {t.data.projectSlug && (
-                <div class="mt-1">
-                  <a class="text-zinc-200 hover:text-white" href={`/projects/${t.data.projectSlug}/`}>
-                    View related project →
-                  </a>
-                </div>
-              )}
-            </div>
-          </article>
-        );
-      })}
+                {t.data.projectSlug && (
+                  <div class="mt-1">
+                    <a class="text-zinc-200 hover:text-white" href={`/projects/${t.data.projectSlug}/`}>
+                      View related project →
+                    </a>
+                  </div>
+                )}
+              </div>
+            </article>
+          );
+        })}
+      </div>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
### Motivation
- Make the mobile navigation expand/collapse with smooth motion and overlay the page instead of pushing content down.
- Allow users to dismiss the mobile nav by clicking outside it or pressing `Escape` for a better UX.
- Remove the visible “Menu” label so the toggle is icon-only while keeping it accessible.
- Let page sections be full-width so background images can span edge-to-edge without being clipped by rounded section borders.

### Description
- Reworked the header in `src/layouts/BaseLayout.astro` to render the mobile nav as an absolutely positioned overlay panel with transition-friendly utility classes and an icon-only toggle button.
- Replaced the simple `hidden` toggle with JS that animates `max-height`, `opacity`, and `translate-y`, and that handles outside-click dismissal and `Escape` key to close the panel.
- Updated page section markup across `src/pages/index.astro`, `src/pages/contact.astro`, `src/pages/testimonials.astro`, `src/pages/projects/index.astro`, and `src/pages/projects/[slug].astro` to use full-width background wrappers with inner `max-w-6xl px-4` containers, removing rounded borders from the outer section wrappers.
- Adjusted header/footer container structure to align with the overlay nav behavior and maintain consistent inner content widths.

### Testing
- Attempted to run the dev server with `npm run dev -- --host 0.0.0.0 --port 4321`, but the run failed because `astro` was not available in the environment.
- Attempted `npm install`, which produced warnings and the process was interrupted, so no successful automated dev/run tests were completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695db39fc6cc8330a6f94877cab42016)