### PR TITLE
Add background image overlays to home sections

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -16,10 +16,10 @@ const featured = projects
 >
   <section class="relative overflow-hidden bg-surface py-10">
     <div
-      class="absolute inset-0 opacity-30 pointer-events-none"
-      style="background: radial-gradient(800px circle at 20% 10%, var(--color-deep), transparent 60%),
-                          radial-gradient(700px circle at 80% 30%, var(--color-primary), transparent 55%);"
+      class="absolute inset-0 bg-cover bg-center pointer-events-none"
+      style="background-image: url('/images/backgrounds/background-3_large.jpg');"
     ></div>
+    <div class="absolute inset-0 bg-zinc-900/20 pointer-events-none"></div>
 
     <div class="relative mx-auto max-w-6xl px-4">
       <h1 class="text-3xl sm:text-4xl font-bold tracking-tight">
@@ -58,7 +58,12 @@ const featured = projects
     </div>
   </section>
 
-  <section class="mt-8">
+  <section class="relative mt-8 overflow-hidden">
+    <div
+      class="absolute inset-0 bg-cover bg-center pointer-events-none"
+      style="background-image: url('/images/backgrounds/background-3_large.jpg');"
+    ></div>
+    <div class="absolute inset-0 bg-zinc-900/20 pointer-events-none"></div>
     <div class="mx-auto max-w-6xl px-4">
       <div class="flex items-end justify-between gap-4">
         <h2 class="text-xl font-semibold">Featured Projects</h2>
@@ -85,7 +90,12 @@ const featured = projects
     </div>
   </section>
 
-  <section class="mt-10 bg-zinc-900/40">
+  <section class="relative mt-10 overflow-hidden bg-zinc-900/40">
+    <div
+      class="absolute inset-0 bg-cover bg-center pointer-events-none"
+      style="background-image: url('/images/backgrounds/background-3_large.jpg');"
+    ></div>
+    <div class="absolute inset-0 bg-zinc-900/20 pointer-events-none"></div>
     <div class="mx-auto max-w-6xl px-4 py-6">
       <h2 class="text-lg font-semibold">Plans Coming Soon</h2>
       <p class="mt-2 text-sm text-zinc-300 max-w-2xl">


### PR DESCRIPTION
### Motivation
- Add a consistent background image and a subtle gray mask to the home page sections so the photography appears slightly grayed out.
- Use the specific image at `/images/backgrounds/background-3_large.jpg` for the hero, featured projects, and plans sections.

### Description
- Updated `src/pages/index.astro` to replace the hero radial gradients with a full-size background image `style="background-image: url('/images/backgrounds/background-3_large.jpg');"`.
- Added matching background image layers and a low-opacity gray overlay `bg-zinc-900/20` to the Featured Projects and Plans sections.
- Ensured sections use `relative`/`overflow-hidden` and background layers use `absolute inset-0 bg-cover bg-center pointer-events-none` so content remains interactive.

### Testing
- Attempted to run `npm ci` as the install verification step, but the process stalled/interrupted and could not complete.
- Did not run `npm run build` so an automated static build verification was not completed.
- The modified file `src/pages/index.astro` was saved and committed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696089f48314833088a3d0d6c49f3ccd)